### PR TITLE
Add device management API

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -12,7 +12,7 @@ class DeviceController extends Controller
      */
     public function index()
     {
-        //
+        return Device::all();
     }
 
     /**
@@ -28,8 +28,13 @@ class DeviceController extends Controller
      */
     public function store(Request $request)
     {
-        $device = Device::create($request->toArray());
-        return $device;
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+        ]);
+
+        $device = Device::create($data);
+
+        return response()->json($device, 201);
     }
 
     /**
@@ -37,7 +42,7 @@ class DeviceController extends Controller
      */
     public function show(Device $device)
     {
-        //
+        return $device;
     }
 
     /**
@@ -53,7 +58,13 @@ class DeviceController extends Controller
      */
     public function update(Request $request, Device $device)
     {
-        //
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+        ]);
+
+        $device->update($data);
+
+        return $device;
     }
 
     /**
@@ -61,6 +72,8 @@ class DeviceController extends Controller
      */
     public function destroy(Device $device)
     {
-        //
+        $device->delete();
+
+        return response()->noContent();
     }
 }

--- a/database/factories/DeviceFactory.php
+++ b/database/factories/DeviceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Device>
+ */
+class DeviceFactory extends Factory
+{
+    protected $model = \App\Models\Device::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->word(),
+        ];
+    }
+}
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/DeviceManagementTest.php
+++ b/tests/Feature/DeviceManagementTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeviceManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_device(): void
+    {
+        $response = $this->postJson('/api/device', [
+            'title' => 'Light',
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('devices', ['title' => 'Light']);
+    }
+
+    public function test_user_can_view_devices(): void
+    {
+        Device::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/device');
+
+        $response->assertOk()
+                 ->assertJsonCount(2);
+    }
+
+    public function test_user_can_update_device(): void
+    {
+        $device = Device::factory()->create(['title' => 'Old']);
+
+        $response = $this->putJson('/api/device/' . $device->id, [
+            'title' => 'New',
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'title' => 'New']);
+    }
+
+    public function test_user_can_delete_device(): void
+    {
+        $device = Device::factory()->create();
+
+        $response = $this->deleteJson('/api/device/' . $device->id);
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('devices', ['id' => $device->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for `Device`
- add `DeviceFactory` for testing
- enable sqlite for tests
- add feature tests for device management

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687a4c57c4948325aa3693131a14aea1