### PR TITLE
Add Guest CRUD endpoints

### DIFF
--- a/app/Http/Controllers/GuestController.php
+++ b/app/Http/Controllers/GuestController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Guest;
+use Illuminate\Http\Request;
+
+class GuestController extends Controller
+{
+    /**
+     * Display a listing of the guests.
+     */
+    public function index()
+    {
+        return Guest::all();
+    }
+
+    /**
+     * Store a newly created guest in storage.
+     */
+    public function store(Request $request)
+    {
+        $guest = Guest::create($request->toArray());
+        return response()->json($guest, 201);
+    }
+
+    /**
+     * Display the specified guest.
+     */
+    public function show(Guest $guest)
+    {
+        return $guest;
+    }
+
+    /**
+     * Update the specified guest in storage.
+     */
+    public function update(Request $request, Guest $guest)
+    {
+        $guest->update($request->toArray());
+        return $guest;
+    }
+
+    /**
+     * Remove the specified guest from storage.
+     */
+    public function destroy(Guest $guest)
+    {
+        $guest->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/Guest.php
+++ b/app/Models/Guest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Guest extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+}

--- a/database/migrations/2024_04_25_175056_create_guests_table.php
+++ b/database/migrations/2024_04_25_175056_create_guests_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guests', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('guests');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\DeviceController;
+use App\Http\Controllers\GuestController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -20,3 +21,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::apiResource('/device', DeviceController::class);
+Route::apiResource('/guests', GuestController::class);

--- a/tests/Feature/GuestApiTest.php
+++ b/tests/Feature/GuestApiTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuestApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_crud()
+    {
+        // Create
+        $response = $this->postJson('/api/guests', ['name' => 'Alice']);
+        $response->assertStatus(201)->assertJson(['name' => 'Alice']);
+        $guestId = $response->json('id');
+
+        // Read
+        $this->getJson("/api/guests/{$guestId}")
+            ->assertStatus(200)
+            ->assertJson(['id' => $guestId, 'name' => 'Alice']);
+
+        // Update
+        $this->putJson("/api/guests/{$guestId}", ['name' => 'Bob'])
+            ->assertStatus(200)
+            ->assertJson(['id' => $guestId, 'name' => 'Bob']);
+
+        // Index
+        $this->getJson('/api/guests')
+            ->assertStatus(200)
+            ->assertJsonFragment(['name' => 'Bob']);
+
+        // Delete
+        $this->deleteJson("/api/guests/{$guestId}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('guests', ['id' => $guestId]);
+    }
+}


### PR DESCRIPTION
## Summary
- create Guest model, migration, and controller
- expose Guest API resource routes
- configure tests to use sqlite
- add feature test covering full Guest CRUD flow

## Testing
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892105aa708325b258a6066d6b9bbf